### PR TITLE
Increase update lease status call frequency

### DIFF
--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -158,7 +158,7 @@ variable "principal_policy" {
 variable "fan_out_update_lease_status_schedule_expression" {
   type        = string
   description = "Update lease status schedule"
-  default     = "rate(6 hours)"
+  default     = "0 5/30 * * ? *"
 }
 
 variable "update_lease_status_enabled" {

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -158,7 +158,7 @@ variable "principal_policy" {
 variable "fan_out_update_lease_status_schedule_expression" {
   type        = string
   description = "Update lease status schedule"
-  default     = "0 5/30 * * ? *"
+  default     = "cron(0 5/30 * * ? *)"
 }
 
 variable "update_lease_status_enabled" {


### PR DESCRIPTION
Calculate account's usage every 30 minutes starting the 5th minute each hour. This PR in combination with AWS Cost Explorer calculating cost each hour, should result in leased accounts costs being updated in a time window between 1 to 1:30 hours